### PR TITLE
Fix bug in :str parameter

### DIFF
--- a/lib/Lingua/Conjunction.rakumod
+++ b/lib/Lingua/Conjunction.rakumod
@@ -43,7 +43,7 @@ my sub conjunction (
     $str
       .subst(
         / '[' (<-[|]>*) '|' (<-[\]]>*) ']'/,
-        { @els.elems == 0 || @els.elems > 2 ?? $1 !! $0 }, :g
+        { @els.elems == 0 || @els.elems > 1 ?? $1 !! $0 }, :g
       )
       .subst('|list|', $list, :g)
 }


### PR DESCRIPTION
Currently, the documentation says :str "can use special sequence [|] (e.g. octop[us|i]) where string to the left of the | will be used when the list contains just one item and the string to the right will be used otherwise," but it uses the string to the left of the | when the list contains one OR TWO items.

This change corrects the behavior to conform with the documentation.